### PR TITLE
Use geospatial ID lookups for admin region refinement

### DIFF
--- a/Backend/VisitedAreasWorker.cs
+++ b/Backend/VisitedAreasWorker.cs
@@ -20,8 +20,14 @@ public class VisitedAreasWorker(
 {
     private readonly ServiceBusClient _serviceBusClient = serviceBusClient;
     private const int AreaTileZoom = 8;
-    private const int RegionTileZoom = 6;
     private const int AdminLevelRegion = 4;
+
+    private sealed record VisitedAreaCandidate(
+        string AreaId,
+        string Name,
+        string AreaType,
+        string? Wikidata,
+        string? WikimediaCommons);
 
     [Function(nameof(VisitedAreasWorker))]
     public async Task Run(
@@ -62,37 +68,55 @@ public class VisitedAreasWorker(
             }
 
             var activityPoints = GeoSpatialFunctions.DecodePolyline(activity.Polyline ?? activity.SummaryPolyline ?? string.Empty).ToList();
-            var visitedAreas = FindVisitedAreas(activityPoints, nearbyAreas).ToList();
+            var nearbyRegions = (await FetchVisitedRegionSummaries(activityPoints, cancellationToken)).ToList();
+            var visitedAreas = FindVisitedAreas(activityPoints, nearbyAreas, nearbyRegions).ToList();
 
             _logger.LogInformation("Activity {ActivityId} visits {AreaCount} areas", activityId, visitedAreas.Count);
 
-            var documents = new List<VisitedArea>();
+            if (visitedAreas.Count == 0)
+            {
+                await actions.CompleteMessageAsync(job);
+                return;
+            }
+
+            var partitionKey = new PartitionKey(activity.UserId);
+            var documentIds = visitedAreas
+                .Select(area => activity.UserId + "-" + area.AreaId)
+                .ToList();
+            var existingDocs = (await _visitedAreasCollection.GetByIdsAsync(documentIds, cancellationToken))
+                .ToDictionary(doc => doc.Id, StringComparer.Ordinal);
+
+            var toCreate = new List<VisitedArea>();
+            var toPatch = new List<(string Id, IReadOnlyList<PatchOperation> Operations)>();
             foreach (var area in visitedAreas)
             {
-                var areaId = area.LogicalId;
-                var documentId = activity.UserId + "-" + areaId;
-                var partitionKey = new PartitionKey(activity.UserId);
-                var areaType = area.Kind == FeatureKinds.AdminBoundary
-                    ? "region"
-                    : (area.Properties.TryGetValue("areaType", out var existingAreaType) ? existingAreaType?.ToString() ?? "protected_area" : "protected_area");
-                var doc = await _visitedAreasCollection.GetByIdMaybe(documentId, partitionKey)
-                    ?? new VisitedArea
+                var documentId = activity.UserId + "-" + area.AreaId;
+                if (existingDocs.TryGetValue(documentId, out var existing))
+                {
+                    if (!existing.ActivityIds.Contains(activity.Id))
                     {
-                        Id = documentId,
-                        UserId = activity.UserId,
-                        AreaId = areaId,
-                        Name = area.Properties.TryGetValue("name", out var name) ? name?.ToString() ?? areaId : areaId,
-                        AreaType = areaType,
-                        Wikidata = area.Properties.TryGetValue("wikidata", out var wikidata) ? wikidata?.ToString() : null,
-                        WikimediaCommons = area.Properties.TryGetValue("wikimedia_commons", out var wmc) ? wmc?.ToString() : null,
-                        ActivityIds = []
-                    };
-                doc.ActivityIds.Add(activity.Id);
-                documents.Add(doc);
+                        toPatch.Add((documentId, [
+                            PatchOperation.Add("/activityIds/-", activity.Id)
+                        ]));
+                    }
+                    continue;
+                }
+
+                toCreate.Add(new VisitedArea
+                {
+                    Id = documentId,
+                    UserId = activity.UserId,
+                    AreaId = area.AreaId,
+                    Name = area.Name,
+                    AreaType = area.AreaType,
+                    Wikidata = area.Wikidata,
+                    WikimediaCommons = area.WikimediaCommons,
+                    ActivityIds = [activity.Id]
+                });
             }
 
             await actions.RenewMessageLockAsync(job);
-            await _visitedAreasCollection.BulkUpsert(documents);
+            await _visitedAreasCollection.ExecuteBatch(partitionKey, creates: toCreate, patches: toPatch, cancellationToken: cancellationToken);
             await actions.CompleteMessageAsync(job);
         }
         catch (Exception ex)
@@ -103,14 +127,39 @@ public class VisitedAreasWorker(
         }
     }
 
-    private static IEnumerable<StoredFeature> FindVisitedAreas(List<Coordinate> activityPoints, IEnumerable<StoredFeature> areas)
+    private static IEnumerable<VisitedAreaCandidate> FindVisitedAreas(
+        List<Coordinate> activityPoints,
+        IEnumerable<StoredFeature> areas,
+        IEnumerable<StoredFeatureSummary> regions)
     {
         foreach (var area in areas)
         {
             if (ActivityVisitsArea(activityPoints, area.Geometry))
-                yield return area;
+            {
+                var areaId = area.LogicalId;
+                yield return new VisitedAreaCandidate(
+                    areaId,
+                    GetPropertyValue(area.Properties, "name") ?? areaId,
+                    GetPropertyValue(area.Properties, "areaType") ?? "protected_area",
+                    GetPropertyValue(area.Properties, "wikidata"),
+                    GetPropertyValue(area.Properties, "wikimedia_commons"));
+            }
+        }
+
+        foreach (var region in regions)
+        {
+            var regionId = region.LogicalId;
+            yield return new VisitedAreaCandidate(
+                regionId,
+                GetPropertyValue(region.Properties, "name") ?? regionId,
+                "region",
+                GetPropertyValue(region.Properties, "wikidata"),
+                GetPropertyValue(region.Properties, "wikimedia_commons"));
         }
     }
+
+    private static string? GetPropertyValue(IDictionary<string, dynamic> properties, string key)
+        => properties.TryGetValue(key, out var value) ? value?.ToString() : null;
 
     private static bool ActivityVisitsArea(List<Coordinate> activityPoints, Geometry geometry)
     {
@@ -154,7 +203,6 @@ public class VisitedAreasWorker(
     private async Task<IEnumerable<StoredFeature>> FetchNearbyAreas(IEnumerable<Activity> activities)
     {
         var areaTileIndices = new HashSet<(int x, int y)>();
-        var regionTileIndices = new HashSet<(int x, int y)>();
         foreach (var activity in activities)
         {
             var polyline = activity.SummaryPolyline ?? activity.Polyline;
@@ -164,16 +212,24 @@ public class VisitedAreasWorker(
             var points = GeoSpatialFunctions.DecodePolyline(polyline);
             foreach (var tile in SlippyTileCalculator.TileIndicesByLine(points, AreaTileZoom))
                 areaTileIndices.Add(tile);
-            foreach (var tile in SlippyTileCalculator.TileIndicesByLine(points, RegionTileZoom))
-                regionTileIndices.Add(tile);
         }
 
-        var areasTask = _protectedAreasCollection.FetchByTiles(areaTileIndices, AreaTileZoom, followPointers: true);
-        var regionsTask = _adminBoundariesCollection.FetchByTiles(regionTileIndices, AdminLevelRegion, RegionTileZoom, followPointers: true);
-        var (areas, regions) = (await areasTask, await regionsTask);
+        var areas = (await _protectedAreasCollection.FetchByTiles(areaTileIndices, AreaTileZoom, followPointers: true)).ToList();
+        _logger.LogInformation("Found {Count} nearby protected areas", areas.Count);
+        return areas;
+    }
 
-        var allFeatures = areas.Concat(regions).ToList();
-        _logger.LogInformation("Found {Count} nearby areas and regions", allFeatures.Count);
-        return allFeatures;
+    private async Task<IEnumerable<StoredFeatureSummary>> FetchVisitedRegionSummaries(
+        List<Coordinate> activityPoints,
+        CancellationToken cancellationToken)
+    {
+        var sampledPoints = GetSampledIndices(activityPoints.Count)
+            .Select(index => activityPoints[index])
+            .ToList();
+
+        var regions = (await _adminBoundariesCollection.FindBoundarySummariesContainingAnyPoint(
+            sampledPoints, AdminLevelRegion, cancellationToken)).ToList();
+        _logger.LogInformation("Found {Count} visited admin regions via geospatial lookup", regions.Count);
+        return regions;
     }
 }

--- a/Shared.Tests/TiledCollectionClientTests.cs
+++ b/Shared.Tests/TiledCollectionClientTests.cs
@@ -104,6 +104,31 @@ public class TiledCollectionClientTests
         Assert.Empty(result);
     }
 
+    [Fact]
+    public async Task ResolvePointers_WhenResolvedDocumentsHaveDuplicateIds_DeduplicatesBeforeDictionaryLookup()
+    {
+        const string kind = FeatureKinds.Peak;
+        const string featureId = "duplicate-feature";
+        const string storedDocumentId = "peak:duplicate-feature";
+
+        var client = new DuplicateResolvePointersClient(null!, new LoggerFactory(), kind, storeZoom: 11);
+        var pointer = StoredFeature.CreatePointer(
+            kind,
+            featureId,
+            x: 1,
+            y: 1,
+            zoom: 11,
+            storedX: 1,
+            storedY: 1,
+            storedZoom: 11,
+            storedDocumentId);
+
+        var result = (await client.ResolvePointersPublic(new[] { pointer }, CancellationToken.None)).ToList();
+
+        Assert.Single(result);
+        Assert.Equal(storedDocumentId, result[0].Id);
+    }
+
     private sealed class NoFetcherTiledCollectionClient : TiledCollectionClient
     {
         public NoFetcherTiledCollectionClient(Container container, ILoggerFactory loggerFactory, string kind, int storeZoom)
@@ -113,5 +138,34 @@ public class TiledCollectionClientTests
 
         public Task<IEnumerable<StoredFeature>> FetchMissingTilePublic(int x, int y, int zoom, CancellationToken cancellationToken)
             => base.FetchMissingTile(x, y, zoom, cancellationToken);
+    }
+
+    private sealed class DuplicateResolvePointersClient : TiledCollectionClient
+    {
+        public DuplicateResolvePointersClient(Container container, ILoggerFactory loggerFactory, string kind, int storeZoom)
+            : base(container, loggerFactory, kind, (_, _, cancellationToken) => Task.FromResult(Enumerable.Empty<Feature>()), null, storeZoom)
+        {
+        }
+
+        public Task<IEnumerable<StoredFeature>> ResolvePointersPublic(IEnumerable<StoredFeature> documents, CancellationToken cancellationToken)
+            => base.ResolvePointers(documents, cancellationToken);
+
+        public override Task<IEnumerable<StoredFeature>> GetByIdsAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default)
+        {
+            var id = ids.Single();
+            var duplicate = new StoredFeature
+            {
+                Id = id,
+                FeatureId = id,
+                Kind = FeatureKinds.Peak,
+                X = 0,
+                Y = 0,
+                Zoom = 11,
+                Geometry = new Point(new Position(0, 0)),
+                Properties = new Dictionary<string, dynamic>()
+            };
+
+            return Task.FromResult((IEnumerable<StoredFeature>)new[] { duplicate, duplicate });
+        }
     }
 }

--- a/Shared/Models/StoredFeatureSummary.cs
+++ b/Shared/Models/StoredFeatureSummary.cs
@@ -1,0 +1,20 @@
+using System.Text.Json.Serialization;
+
+namespace Shared.Models;
+
+public sealed class StoredFeatureSummary
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    public string? FeatureId { get; init; }
+
+    public string? Kind { get; init; }
+
+    public IDictionary<string, dynamic> Properties { get; init; } = new Dictionary<string, dynamic>();
+
+    [JsonIgnore]
+    public string LogicalId => !string.IsNullOrWhiteSpace(FeatureId)
+        ? FeatureId
+        : StoredFeature.NormalizeFeatureId(Kind, Id);
+}

--- a/Shared/Services/AdminBoundariesCollectionClient.cs
+++ b/Shared/Services/AdminBoundariesCollectionClient.cs
@@ -47,6 +47,20 @@ public class AdminBoundariesCollectionClient(Container container, ILoggerFactory
         }
     }
 
+    public Task<IEnumerable<StoredFeatureSummary>> FindBoundarySummariesContainingAnyPoint(
+        IEnumerable<Coordinate> points,
+        int adminLevel,
+        CancellationToken cancellationToken = default)
+    {
+        var filter = "c.properties.adminLevel = @adminLevel";
+        var filterParameters = new Dictionary<string, object?>
+        {
+            ["@adminLevel"] = adminLevel.ToString()
+        };
+
+        return FindFeatureSummariesContainingAnyPoint(points, filter, filterParameters, cancellationToken);
+    }
+
     protected override async Task<IEnumerable<StoredFeature>> FetchMissingTile(int x, int y, int zoom, CancellationToken cancellationToken)
     {
         var adminLevel = _currentAdminLevel.Value ?? throw new InvalidOperationException("Admin level must be set before calling FetchMissingTile.");

--- a/Shared/Services/AdminBoundaryMetricsEnricher.cs
+++ b/Shared/Services/AdminBoundaryMetricsEnricher.cs
@@ -46,14 +46,9 @@ public sealed class AdminBoundaryMetricsEnricher(
     {
         var ops = new List<PatchOperation>();
         var centroid = GeometryCentroidHelper.GetCentroid(boundary.Geometry);
-        var centroidTile = SlippyTileCalculator.WGS84ToTileIndex(centroid, CountryTileZoom);
 
-        var countries = await _adminBoundariesCollection.FetchByTiles(
-            [centroidTile], adminLevel: 2, zoom: CountryTileZoom, followPointers: true, cancellationToken: cancellationToken);
-
-        var country = countries.FirstOrDefault(c =>
-            !StoredFeature.IsPointerDocument(c)
-            && RouteFeatureMatcher.IsPointInGeometry(centroid, c.Geometry));
+        var country = (await _adminBoundariesCollection.FindBoundarySummariesContainingAnyPoint(
+            [centroid], adminLevel: 2, cancellationToken: cancellationToken)).FirstOrDefault();
 
         if (country != null)
         {

--- a/Shared/Services/CollectionClient.cs
+++ b/Shared/Services/CollectionClient.cs
@@ -81,7 +81,7 @@ public class CollectionClient<T>(Container _container, ILoggerFactory loggerFact
         }
     }
 
-    public async Task<IEnumerable<T>> GetByIdsAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default)
+    public virtual async Task<IEnumerable<T>> GetByIdsAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default)
     {
         const int MaxIdsPerQuery = 256;
         var allDocuments = new List<T>();
@@ -107,7 +107,8 @@ public class CollectionClient<T>(Container _container, ILoggerFactory loggerFact
             allDocuments.AddRange(queryResult);
         }
 
-        return allDocuments;
+        return allDocuments
+            .DistinctBy(document => document.Id, StringComparer.Ordinal);
     }
 
     public async Task<List<string>> GetAllIds(CancellationToken cancellationToken = default)

--- a/Shared/Services/TiledCollectionClient.cs
+++ b/Shared/Services/TiledCollectionClient.cs
@@ -229,6 +229,8 @@ public class TiledCollectionClient(
     // when the document geometry is a polygon/multi-polygon that contains it.
     private const string WithinPredicate =
         "ST_WITHIN({'type':'Point','coordinates':[@lng,@lat]}, c.geometry)";
+    private const int MaxPointsPerContainmentQuery = 25;
+    private const string StoredFeatureSummaryProjection = "c.id, c.featureId, c.kind, c.properties";
 
     // Cosmos SQL predicate that matches documents whose geometry is within @radius
     // metres of the GeoJSON point passed in via @lng/@lat.
@@ -302,6 +304,67 @@ public class TiledCollectionClient(
             pointerStoredIds, "VALUE c.id", WithinPredicate, spatialParameters, additionalFilter, additionalParameters, cancellationToken);
 
         return matchIds.Concat(resolvedIds).Distinct(StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Returns lightweight feature metadata for documents containing any of the supplied points.
+    /// Points are grouped by storage tile and queried in small batches so Cosmos can use the
+    /// partition key/tile pre-filter before evaluating the geospatial predicates.
+    /// </summary>
+    public Task<IEnumerable<StoredFeatureSummary>> FindFeatureSummariesContainingAnyPoint(
+        IEnumerable<Coordinate> points,
+        CancellationToken cancellationToken = default)
+        => FindFeatureSummariesContainingAnyPoint(points, null, null, cancellationToken);
+
+    public async Task<IEnumerable<StoredFeatureSummary>> FindFeatureSummariesContainingAnyPoint(
+        IEnumerable<Coordinate> points,
+        string? additionalFilter,
+        IReadOnlyDictionary<string, object?>? additionalParameters,
+        CancellationToken cancellationToken = default)
+    {
+        var pointsByTile = points
+            .Select(point => new { Point = point, Tile = SlippyTileCalculator.WGS84ToTileIndex(point, _storeZoom) })
+            .DistinctBy(item => (item.Tile, item.Point.Lng, item.Point.Lat))
+            .GroupBy(item => item.Tile, item => item.Point)
+            .ToList();
+
+        if (pointsByTile.Count == 0)
+            return [];
+
+        var results = new List<StoredFeatureSummary>();
+        foreach (var tileGroup in pointsByTile)
+        {
+            var pointerStoredIds = (await GetPointerStoredIdsAtTile(
+                tileGroup.Key, additionalFilter, additionalParameters, cancellationToken)).ToList();
+
+            foreach (var pointBatch in tileGroup.Chunk(MaxPointsPerContainmentQuery))
+            {
+                var spatialPredicate = BuildWithinAnyPointPredicate(pointBatch);
+                var spatialParameters = WithinAnyPointParameters(pointBatch);
+
+                var matches = await QueryAtTileWithSpatialPredicate<StoredFeatureSummary>(
+                    tileGroup.Key,
+                    StoredFeatureSummaryProjection,
+                    spatialPredicate,
+                    spatialParameters,
+                    additionalFilter,
+                    additionalParameters,
+                    cancellationToken);
+                results.AddRange(matches);
+
+                var resolved = await ResolveStoredIdsWithSpatialPredicate<StoredFeatureSummary>(
+                    pointerStoredIds,
+                    StoredFeatureSummaryProjection,
+                    spatialPredicate,
+                    spatialParameters,
+                    additionalFilter,
+                    additionalParameters,
+                    cancellationToken);
+                results.AddRange(resolved);
+            }
+        }
+
+        return results.DistinctBy(summary => summary.Id, StringComparer.Ordinal);
     }
 
     /// <summary>
@@ -407,6 +470,27 @@ public class TiledCollectionClient(
         ["@lat"] = point.Lat,
         ["@radius"] = radiusMeters,
     };
+
+    private static string BuildWithinAnyPointPredicate(IReadOnlyList<Coordinate> points)
+    {
+        if (points.Count == 1)
+            return "ST_WITHIN({'type':'Point','coordinates':[@lng0,@lat0]}, c.geometry)";
+
+        return "(" + string.Join(" OR ", points.Select((_, index) =>
+            $"ST_WITHIN({{'type':'Point','coordinates':[@lng{index},@lat{index}]}}, c.geometry)")) + ")";
+    }
+
+    private static Dictionary<string, object?> WithinAnyPointParameters(IReadOnlyList<Coordinate> points)
+    {
+        var parameters = new Dictionary<string, object?>(points.Count * 2);
+        for (var index = 0; index < points.Count; index++)
+        {
+            parameters[$"@lng{index}"] = points[index].Lng;
+            parameters[$"@lat{index}"] = points[index].Lat;
+        }
+
+        return parameters;
+    }
 
     private async Task<IEnumerable<T>> QueryAtTileWithSpatialPredicate<T>(
         (int x, int y) tile,

--- a/Shared/Services/TiledCollectionClient.cs
+++ b/Shared/Services/TiledCollectionClient.cs
@@ -706,6 +706,8 @@ public class TiledCollectionClient(
             return documentList;
 
         var resolvedDocuments = (await GetByIdsAsync(pointedIds!, cancellationToken))
+            .GroupBy(document => document.Id, StringComparer.Ordinal)
+            .Select(group => group.First())
             .ToDictionary(document => document.Id, StringComparer.Ordinal);
 
         return documentList


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add lightweight stored-feature summaries and batched multi-point containment lookups to the tiled Cosmos client.
- Switch visited admin region refinement to query region summaries via Cosmos geospatial predicates instead of loading full region polygons into the worker.
- Patch existing visited-area documents and create only missing documents in partition batches.
- Use the same ID/summary geospatial lookup for admin-boundary country enrichment to avoid pulling full country geometries for centroid checks.

## Verification
- `git diff --check`
- `dotnet test` could not run in this environment because `dotnet` is not installed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d44538e-d1e1-4db4-a499-a37789af4051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d44538e-d1e1-4db4-a499-a37789af4051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

