### PR TITLE
Fix .NET build split overloads

### DIFF
--- a/Backend/RaceHtmlScraper.cs
+++ b/Backend/RaceHtmlScraper.cs
@@ -1026,7 +1026,7 @@ public static partial class RaceHtmlScraper
         var tldIdx = host.LastIndexOf('.');
         if (tldIdx > 0) host = host[..tldIdx];
         // Split on dots and hyphens.
-        return host.Split(['.', '-'], StringSplitOptions.RemoveEmptyEntries)
+        return host.Split(new[] { '.', '-' }, StringSplitOptions.RemoveEmptyEntries)
             .Where(w => w.Length >= 3)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
     }

--- a/Backend/RaceScrapeDiscovery.cs
+++ b/Backend/RaceScrapeDiscovery.cs
@@ -183,7 +183,7 @@ public static partial class RaceScrapeDiscovery
             return null;
 
         var parts = distanceVerbose
-            .Split([',', ';'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            .Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
         string? bestToken = null;
         double bestDelta = double.MaxValue;
@@ -221,7 +221,7 @@ public static partial class RaceScrapeDiscovery
             return null;
 
         var parts = distanceVerbose
-            .Split([',', ';'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            .Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
         var formatted = new List<string>(parts.Length);
         foreach (var part in parts)
@@ -1510,7 +1510,7 @@ public static partial class RaceScrapeDiscovery
     private static IReadOnlyList<(double Km, string Formatted)> ParseVerboseDistanceParts(string distanceVerbose)
     {
         var parts = distanceVerbose
-            .Split([',', ';'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            .Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
         var result = new List<(double, string)>(parts.Length);
         foreach (var part in parts)

--- a/RaceTileJob.Tests/RaceTileBuildServiceTests.cs
+++ b/RaceTileJob.Tests/RaceTileBuildServiceTests.cs
@@ -17,10 +17,9 @@ public class RaceTileBuildServiceTests
         Assert.Contains(output, args);
         Assert.Contains("--layer=trails", args);
         Assert.Contains("--minimum-zoom=0", args);
-        Assert.Contains("--maximum-zoom=14", args);
-        Assert.Contains("--simplification=10", args);
-        Assert.Contains("--cluster-distance=8", args);
-        Assert.Contains("--coalesce-smallest-as-needed", args);
+        Assert.Contains("-zg", args);
+        Assert.Contains("-r1", args);
+        Assert.Contains("--drop-densest-as-needed", args);
         Assert.Contains("--no-tile-size-limit", args);
         Assert.Contains("--no-feature-limit", args);
         Assert.Contains("--force", args);

--- a/Shared/Services/RaceTypeNormalizer.cs
+++ b/Shared/Services/RaceTypeNormalizer.cs
@@ -8,7 +8,7 @@ public static class RaceTypeNormalizer
             return null;
 
         var parts = raceType
-            .Split([',', ';', '/', '_'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Split(new[] { ',', ';', '/', '_' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
             .Select(p => p.ToLowerInvariant())
             .Select(p => RaceTypeAliases.TryGetValue(p, out var mapped) ? mapped : p)
             .Where(p => p.Length > 0)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Fix ambiguous `string.Split` calls so the .NET 8 solution builds on the current SDK.
- Align the RaceTileJob Tippecanoe argument test with the currently checked-in `-zg` / `-r1` / `--drop-densest-as-needed` arguments.

### Validation
- `dotnet restore strava.sln`
- `dotnet build strava.sln --no-restore`
- `dotnet test strava.sln`
- Started Azurite plus the API and Backend Azure Functions hosts locally; verification transcript: [dev_environment_verification.log](https://cursor.com/agents/bc-c1498c1d-d0e1-4e7d-b3bc-a5beb9eb116c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdev_environment_verification.log)

### Notes
- Local `local.settings.json` files were created with non-secret emulator/placeholders and are git-ignored.
- RaceTileJob still requires real Cosmos DB and Blob Storage connection strings for a full production-like run, as documented in `RaceTileJob/README.md`.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1498c1d-d0e1-4e7d-b3bc-a5beb9eb116c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1498c1d-d0e1-4e7d-b3bc-a5beb9eb116c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

