### PR TITLE
Move race discovery to service bus pages

### DIFF
--- a/API/Endpoints/Admin/GetOrganizerStats.cs
+++ b/API/Endpoints/Admin/GetOrganizerStats.cs
@@ -59,6 +59,14 @@ public class GetOrganizerStats(
                 new QueryDefinition(
                     $"SELECT VALUE COUNT(1) FROM c WHERE IS_DEFINED(c.discovery[\"{agent}\"])")));
 
+        // ── Per discovery agent: missing-geometry discovery count ────────────
+        var agentMissingGeometryTasks = DiscoveryAgents.ToDictionary(
+            agent => agent,
+            agent => raceOrganizerClient.ExecuteQueryAsync<int>(
+                new QueryDefinition(
+                    $"SELECT VALUE COUNT(1) FROM c JOIN d IN c.discovery[\"{agent}\"] " +
+                    $"WHERE NOT IS_DEFINED(d.latitude) OR NOT IS_DEFINED(d.longitude)")));
+
         // ── Per discovery agent: exclusive count (only this agent found it) ──
         var agentExclusiveTasks = DiscoveryAgents.ToDictionary(
             agent => agent,
@@ -101,6 +109,7 @@ public class GetOrganizerStats(
             withBothTask, noDiscoveryNoScraperTask, topDiscoveryOrganizersTask,
         };
         allTasks.AddRange(agentCountTasks.Values);
+        allTasks.AddRange(agentMissingGeometryTasks.Values);
         allTasks.AddRange(agentExclusiveTasks.Values);
         allTasks.AddRange(scraperCountTasks.Values);
         allTasks.AddRange(scraperWithRoutesTasks.Values);
@@ -130,6 +139,8 @@ public class GetOrganizerStats(
                 {
                     // Organisers this agent discovered (any overlap with other agents)
                     discoveries = agentCountTasks[agent].Result.FirstOrDefault(),
+                    // Discoveries for this agent missing lat/lon geometry.
+                    missingGeometry = agentMissingGeometryTasks[agent].Result.FirstOrDefault(),
                     // Organisers ONLY this agent found — no other agent has them
                     exclusive = agentExclusiveTasks[agent].Result.FirstOrDefault(),
                 }),

--- a/API/Endpoints/Admin/GetOrganizerStats.cs
+++ b/API/Endpoints/Admin/GetOrganizerStats.cs
@@ -31,158 +31,118 @@ public class GetOrganizerStats(
         if (!IsAuthorized(req))
             return req.CreateResponse(HttpStatusCode.Unauthorized);
 
-        // ── Overview ─────────────────────────────────────────────────────────
-        var totalTask = raceOrganizerClient.ExecuteQueryAsync<int>(
-            new QueryDefinition("SELECT VALUE COUNT(1) FROM c"));
+        var queryRequestOptions = new QueryRequestOptions
+        {
+            MaxConcurrency = 1,
+            MaxBufferedItemCount = 1,
+        };
 
-        var assembledTask = raceOrganizerClient.ExecuteQueryAsync<int>(
-            new QueryDefinition("SELECT VALUE COUNT(1) FROM c WHERE IS_DEFINED(c.lastAssembledUtc)"));
-
-        var withAnyDiscoveryTask = raceOrganizerClient.ExecuteQueryAsync<int>(
-            new QueryDefinition("SELECT VALUE COUNT(1) FROM c WHERE IS_DEFINED(c.discovery)"));
-
-        var withAnyScraperTask = raceOrganizerClient.ExecuteQueryAsync<int>(
-            new QueryDefinition("SELECT VALUE COUNT(1) FROM c WHERE IS_DEFINED(c.scrapers)"));
-
-        var withBothTask = raceOrganizerClient.ExecuteQueryAsync<int>(
+        var aggregateStatsTask = raceOrganizerClient.ExecuteQueryAsync<AggregateStats>(
             new QueryDefinition(
-                "SELECT VALUE COUNT(1) FROM c WHERE IS_DEFINED(c.discovery) AND IS_DEFINED(c.scrapers)"));
+                "SELECT " +
+                "COUNT(1) AS total, " +
+                "SUM(IIF(IS_DEFINED(c.lastAssembledUtc), 1, 0)) AS assembled, " +
+                "SUM(IIF(IS_DEFINED(c.discovery), 1, 0)) AS withAnyDiscovery, " +
+                "SUM(IIF(IS_DEFINED(c.scrapers), 1, 0)) AS withAnyScraper, " +
+                "SUM(IIF(IS_DEFINED(c.discovery) AND IS_DEFINED(c.scrapers), 1, 0)) AS withBoth, " +
+                "SUM(IIF(NOT IS_DEFINED(c.discovery) AND NOT IS_DEFINED(c.scrapers), 1, 0)) AS noDiscoveryNoScraper, " +
 
-        var noDiscoveryNoScraperTask = raceOrganizerClient.ExecuteQueryAsync<int>(
-            new QueryDefinition(
-                "SELECT VALUE COUNT(1) FROM c WHERE NOT IS_DEFINED(c.discovery) AND NOT IS_DEFINED(c.scrapers)"));
+                "SUM(IIF(IS_DEFINED(c.discovery[\"utmb\"]), 1, 0)) AS Utmb, " +
+                "SUM(IIF(IS_DEFINED(c.discovery[\"duv\"]), 1, 0)) AS Duv, " +
+                "SUM(IIF(IS_DEFINED(c.discovery[\"itra\"]), 1, 0)) AS Itra, " +
+                "SUM(IIF(IS_DEFINED(c.discovery[\"tracedetrail\"]), 1, 0)) AS TraceDeTrail, " +
+                "SUM(IIF(IS_DEFINED(c.discovery[\"runagain\"]), 1, 0)) AS RunAgain, " +
+                "SUM(IIF(IS_DEFINED(c.discovery[\"loppkartan\"]), 1, 0)) AS Loppkartan, " +
+                "SUM(IIF(IS_DEFINED(c.discovery[\"betrail\"]), 1, 0)) AS BeTrail, " +
+                "SUM(IIF(IS_DEFINED(c.discovery[\"manual\"]), 1, 0)) AS Manual, " +
+                "SUM(IIF(IS_DEFINED(c.discovery[\"manual-mistral\"]), 1, 0)) AS ManualMistral, " +
 
-        // ── Per discovery agent: organiser count ─────────────────────────────
-        var agentCountTasks = DiscoveryAgents.ToDictionary(
-            agent => agent,
-            agent => raceOrganizerClient.ExecuteQueryAsync<int>(
-                new QueryDefinition(
-                    $"SELECT VALUE COUNT(1) FROM c WHERE IS_DEFINED(c.discovery[\"{agent}\"])")));
+                "SUM(IIF(IS_DEFINED(c.discovery[\"utmb\"]) AND NOT IS_DEFINED(c.discovery[\"duv\"]) AND NOT IS_DEFINED(c.discovery[\"itra\"]) AND NOT IS_DEFINED(c.discovery[\"tracedetrail\"]) AND NOT IS_DEFINED(c.discovery[\"runagain\"]) AND NOT IS_DEFINED(c.discovery[\"loppkartan\"]) AND NOT IS_DEFINED(c.discovery[\"betrail\"]) AND NOT IS_DEFINED(c.discovery[\"manual\"]) AND NOT IS_DEFINED(c.discovery[\"manual-mistral\"]), 1, 0)) AS UtmbExclusive, " +
+                "SUM(IIF(NOT IS_DEFINED(c.discovery[\"utmb\"]) AND IS_DEFINED(c.discovery[\"duv\"]) AND NOT IS_DEFINED(c.discovery[\"itra\"]) AND NOT IS_DEFINED(c.discovery[\"tracedetrail\"]) AND NOT IS_DEFINED(c.discovery[\"runagain\"]) AND NOT IS_DEFINED(c.discovery[\"loppkartan\"]) AND NOT IS_DEFINED(c.discovery[\"betrail\"]) AND NOT IS_DEFINED(c.discovery[\"manual\"]) AND NOT IS_DEFINED(c.discovery[\"manual-mistral\"]), 1, 0)) AS DuvExclusive, " +
+                "SUM(IIF(NOT IS_DEFINED(c.discovery[\"utmb\"]) AND NOT IS_DEFINED(c.discovery[\"duv\"]) AND IS_DEFINED(c.discovery[\"itra\"]) AND NOT IS_DEFINED(c.discovery[\"tracedetrail\"]) AND NOT IS_DEFINED(c.discovery[\"runagain\"]) AND NOT IS_DEFINED(c.discovery[\"loppkartan\"]) AND NOT IS_DEFINED(c.discovery[\"betrail\"]) AND NOT IS_DEFINED(c.discovery[\"manual\"]) AND NOT IS_DEFINED(c.discovery[\"manual-mistral\"]), 1, 0)) AS ItraExclusive, " +
+                "SUM(IIF(NOT IS_DEFINED(c.discovery[\"utmb\"]) AND NOT IS_DEFINED(c.discovery[\"duv\"]) AND NOT IS_DEFINED(c.discovery[\"itra\"]) AND IS_DEFINED(c.discovery[\"tracedetrail\"]) AND NOT IS_DEFINED(c.discovery[\"runagain\"]) AND NOT IS_DEFINED(c.discovery[\"loppkartan\"]) AND NOT IS_DEFINED(c.discovery[\"betrail\"]) AND NOT IS_DEFINED(c.discovery[\"manual\"]) AND NOT IS_DEFINED(c.discovery[\"manual-mistral\"]), 1, 0)) AS TraceDeTrailExclusive, " +
+                "SUM(IIF(NOT IS_DEFINED(c.discovery[\"utmb\"]) AND NOT IS_DEFINED(c.discovery[\"duv\"]) AND NOT IS_DEFINED(c.discovery[\"itra\"]) AND NOT IS_DEFINED(c.discovery[\"tracedetrail\"]) AND IS_DEFINED(c.discovery[\"runagain\"]) AND NOT IS_DEFINED(c.discovery[\"loppkartan\"]) AND NOT IS_DEFINED(c.discovery[\"betrail\"]) AND NOT IS_DEFINED(c.discovery[\"manual\"]) AND NOT IS_DEFINED(c.discovery[\"manual-mistral\"]), 1, 0)) AS RunAgainExclusive, " +
+                "SUM(IIF(NOT IS_DEFINED(c.discovery[\"utmb\"]) AND NOT IS_DEFINED(c.discovery[\"duv\"]) AND NOT IS_DEFINED(c.discovery[\"itra\"]) AND NOT IS_DEFINED(c.discovery[\"tracedetrail\"]) AND NOT IS_DEFINED(c.discovery[\"runagain\"]) AND IS_DEFINED(c.discovery[\"loppkartan\"]) AND NOT IS_DEFINED(c.discovery[\"betrail\"]) AND NOT IS_DEFINED(c.discovery[\"manual\"]) AND NOT IS_DEFINED(c.discovery[\"manual-mistral\"]), 1, 0)) AS LoppkartanExclusive, " +
+                "SUM(IIF(NOT IS_DEFINED(c.discovery[\"utmb\"]) AND NOT IS_DEFINED(c.discovery[\"duv\"]) AND NOT IS_DEFINED(c.discovery[\"itra\"]) AND NOT IS_DEFINED(c.discovery[\"tracedetrail\"]) AND NOT IS_DEFINED(c.discovery[\"runagain\"]) AND NOT IS_DEFINED(c.discovery[\"loppkartan\"]) AND IS_DEFINED(c.discovery[\"betrail\"]) AND NOT IS_DEFINED(c.discovery[\"manual\"]) AND NOT IS_DEFINED(c.discovery[\"manual-mistral\"]), 1, 0)) AS BeTrailExclusive, " +
+                "SUM(IIF(NOT IS_DEFINED(c.discovery[\"utmb\"]) AND NOT IS_DEFINED(c.discovery[\"duv\"]) AND NOT IS_DEFINED(c.discovery[\"itra\"]) AND NOT IS_DEFINED(c.discovery[\"tracedetrail\"]) AND NOT IS_DEFINED(c.discovery[\"runagain\"]) AND NOT IS_DEFINED(c.discovery[\"loppkartan\"]) AND NOT IS_DEFINED(c.discovery[\"betrail\"]) AND IS_DEFINED(c.discovery[\"manual\"]) AND NOT IS_DEFINED(c.discovery[\"manual-mistral\"]), 1, 0)) AS ManualExclusive, " +
+                "SUM(IIF(NOT IS_DEFINED(c.discovery[\"utmb\"]) AND NOT IS_DEFINED(c.discovery[\"duv\"]) AND NOT IS_DEFINED(c.discovery[\"itra\"]) AND NOT IS_DEFINED(c.discovery[\"tracedetrail\"]) AND NOT IS_DEFINED(c.discovery[\"runagain\"]) AND NOT IS_DEFINED(c.discovery[\"loppkartan\"]) AND NOT IS_DEFINED(c.discovery[\"betrail\"]) AND NOT IS_DEFINED(c.discovery[\"manual\"]) AND IS_DEFINED(c.discovery[\"manual-mistral\"]), 1, 0)) AS ManualMistralExclusive, " +
 
-        // ── Per discovery agent: missing-geometry discovery count ────────────
-        var agentMissingGeometryTasks = DiscoveryAgents.ToDictionary(
-            agent => agent,
-            agent => raceOrganizerClient.ExecuteQueryAsync<int>(
-                new QueryDefinition(
-                    $"SELECT VALUE COUNT(1) FROM c JOIN d IN c.discovery[\"{agent}\"] " +
-                    $"WHERE NOT IS_DEFINED(d.latitude) OR NOT IS_DEFINED(d.longitude)")));
+                "SUM(IIF(IS_DEFINED(c.discovery[\"utmb\"]) AND EXISTS(SELECT VALUE d FROM d IN c.discovery[\"utmb\"] WHERE NOT IS_DEFINED(d.latitude) OR NOT IS_DEFINED(d.longitude)), 1, 0)) AS UtmbMissingGeometry, " +
+                "SUM(IIF(IS_DEFINED(c.discovery[\"duv\"]) AND EXISTS(SELECT VALUE d FROM d IN c.discovery[\"duv\"] WHERE NOT IS_DEFINED(d.latitude) OR NOT IS_DEFINED(d.longitude)), 1, 0)) AS DuvMissingGeometry, " +
+                "SUM(IIF(IS_DEFINED(c.discovery[\"itra\"]) AND EXISTS(SELECT VALUE d FROM d IN c.discovery[\"itra\"] WHERE NOT IS_DEFINED(d.latitude) OR NOT IS_DEFINED(d.longitude)), 1, 0)) AS ItraMissingGeometry, " +
+                "SUM(IIF(IS_DEFINED(c.discovery[\"tracedetrail\"]) AND EXISTS(SELECT VALUE d FROM d IN c.discovery[\"tracedetrail\"] WHERE NOT IS_DEFINED(d.latitude) OR NOT IS_DEFINED(d.longitude)), 1, 0)) AS TraceDeTrailMissingGeometry, " +
+                "SUM(IIF(IS_DEFINED(c.discovery[\"runagain\"]) AND EXISTS(SELECT VALUE d FROM d IN c.discovery[\"runagain\"] WHERE NOT IS_DEFINED(d.latitude) OR NOT IS_DEFINED(d.longitude)), 1, 0)) AS RunAgainMissingGeometry, " +
+                "SUM(IIF(IS_DEFINED(c.discovery[\"loppkartan\"]) AND EXISTS(SELECT VALUE d FROM d IN c.discovery[\"loppkartan\"] WHERE NOT IS_DEFINED(d.latitude) OR NOT IS_DEFINED(d.longitude)), 1, 0)) AS LoppkartanMissingGeometry, " +
+                "SUM(IIF(IS_DEFINED(c.discovery[\"betrail\"]) AND EXISTS(SELECT VALUE d FROM d IN c.discovery[\"betrail\"] WHERE NOT IS_DEFINED(d.latitude) OR NOT IS_DEFINED(d.longitude)), 1, 0)) AS BeTrailMissingGeometry, " +
+                "SUM(IIF(IS_DEFINED(c.discovery[\"manual\"]) AND EXISTS(SELECT VALUE d FROM d IN c.discovery[\"manual\"] WHERE NOT IS_DEFINED(d.latitude) OR NOT IS_DEFINED(d.longitude)), 1, 0)) AS ManualMissingGeometry, " +
+                "SUM(IIF(IS_DEFINED(c.discovery[\"manual-mistral\"]) AND EXISTS(SELECT VALUE d FROM d IN c.discovery[\"manual-mistral\"] WHERE NOT IS_DEFINED(d.latitude) OR NOT IS_DEFINED(d.longitude)), 1, 0)) AS ManualMistralMissingGeometry, " +
 
-        // ── Per discovery agent: exclusive count (only this agent found it) ──
-        var agentExclusiveTasks = DiscoveryAgents.ToDictionary(
-            agent => agent,
-            agent =>
-            {
-                var notOthers = string.Join(" AND ",
-                    DiscoveryAgents
-                        .Where(a => a != agent)
-                        .Select(a => $"NOT IS_DEFINED(c.discovery[\"{a}\"])"));
-
-                return raceOrganizerClient.ExecuteQueryAsync<int>(
-                    new QueryDefinition(
-                        $"SELECT VALUE COUNT(1) FROM c WHERE IS_DEFINED(c.discovery[\"{agent}\"]) AND {notOthers}"));
-            });
-
-        // ── Per scraper: organiser count + how many yielded at least one route
-        var scraperCountTasks = ScraperAgents.ToDictionary(
-            scraper => scraper,
-            scraper => raceOrganizerClient.ExecuteQueryAsync<int>(
-                new QueryDefinition(
-                    $"SELECT VALUE COUNT(1) FROM c WHERE IS_DEFINED(c.scrapers[\"{scraper}\"])")));
-
-        var scraperWithRoutesTasks = ScraperAgents.ToDictionary(
-            scraper => scraper,
-            scraper => raceOrganizerClient.ExecuteQueryAsync<int>(
-                new QueryDefinition(
-                    $"SELECT VALUE COUNT(1) FROM c " +
-                    $"WHERE IS_DEFINED(c.scrapers[\"{scraper}\"]) " +
-                    $"AND IS_DEFINED(c.scrapers[\"{scraper}\"].routes) " +
-                    $"AND ARRAY_LENGTH(c.scrapers[\"{scraper}\"].routes) > 0")));
-
-        // ── Top organisers by number of discoveries ──────────────────────────
-        var topDiscoveryOrganizersTask = raceOrganizerClient.ExecuteQueryAsync<TopDiscoveryOrganizer>(
-            new QueryDefinition("SELECT c.id, c.url, c.discovery FROM c WHERE IS_DEFINED(c.discovery)"));
+                "SUM(IIF(IS_DEFINED(c.scrapers[\"utmb\"]), 1, 0)) AS utmbTotal, " +
+                "SUM(IIF(IS_DEFINED(c.scrapers[\"itra\"]), 1, 0)) AS itraTotal, " +
+                "SUM(IIF(IS_DEFINED(c.scrapers[\"bfs\"]), 1, 0)) AS bfsTotal, " +
+                "SUM(IIF(IS_DEFINED(c.scrapers[\"utmb\"]) AND IS_DEFINED(c.scrapers[\"utmb\"].routes) AND ARRAY_LENGTH(c.scrapers[\"utmb\"].routes) > 0, 1, 0)) AS utmbWithRoutes, " +
+                "SUM(IIF(IS_DEFINED(c.scrapers[\"itra\"]) AND IS_DEFINED(c.scrapers[\"itra\"].routes) AND ARRAY_LENGTH(c.scrapers[\"itra\"].routes) > 0, 1, 0)) AS itraWithRoutes, " +
+                "SUM(IIF(IS_DEFINED(c.scrapers[\"bfs\"]) AND IS_DEFINED(c.scrapers[\"bfs\"].routes) AND ARRAY_LENGTH(c.scrapers[\"bfs\"].routes) > 0, 1, 0)) AS bfsWithRoutes " +
+                "FROM c"), requestOptions: queryRequestOptions);
 
         // ── Wait for everything ───────────────────────────────────────────────
-        var allTasks = new List<Task>
-        {
-            totalTask, assembledTask, withAnyDiscoveryTask, withAnyScraperTask,
-            withBothTask, noDiscoveryNoScraperTask, topDiscoveryOrganizersTask,
-        };
-        allTasks.AddRange(agentCountTasks.Values);
-        allTasks.AddRange(agentMissingGeometryTasks.Values);
-        allTasks.AddRange(agentExclusiveTasks.Values);
-        allTasks.AddRange(scraperCountTasks.Values);
-        allTasks.AddRange(scraperWithRoutesTasks.Values);
-        await Task.WhenAll(allTasks);
+        await Task.WhenAll(
+            aggregateStatsTask);
 
         // ── Derived totals ────────────────────────────────────────────────────
-        var total = totalTask.Result.FirstOrDefault();
-        var assembled = assembledTask.Result.FirstOrDefault();
-        var withAnyDiscovery = withAnyDiscoveryTask.Result.FirstOrDefault();
-        var totalExclusive = DiscoveryAgents.Sum(a => agentExclusiveTasks[a].Result.FirstOrDefault());
+        var aggregateStats = aggregateStatsTask.Result.FirstOrDefault() ?? new AggregateStats(
+            0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0);
+        var totalExclusive =
+            aggregateStats.UtmbExclusive +
+            aggregateStats.DuvExclusive +
+            aggregateStats.ItraExclusive +
+            aggregateStats.TraceDeTrailExclusive +
+            aggregateStats.RunAgainExclusive +
+            aggregateStats.LoppkartanExclusive +
+            aggregateStats.BeTrailExclusive +
+            aggregateStats.ManualExclusive +
+            aggregateStats.ManualMistralExclusive;
 
         var body = new
         {
             overview = new
             {
-                total,
-                assembled,
-                neverAssembled = total - assembled,
-                withAnyDiscovery,
-                withAnyScraper = withAnyScraperTask.Result.FirstOrDefault(),
-                withBothDiscoveryAndScraper = withBothTask.Result.FirstOrDefault(),
-                noDiscoveryNoScraper = noDiscoveryNoScraperTask.Result.FirstOrDefault(),
+                aggregateStats.Total,
+                aggregateStats.Assembled,
+                neverAssembled = aggregateStats.Total - aggregateStats.Assembled,
+                withAnyDiscovery = aggregateStats.WithAnyDiscovery,
+                withAnyScraper = aggregateStats.WithAnyScraper,
+                withBothDiscoveryAndScraper = aggregateStats.WithBoth,
+                noDiscoveryNoScraper = aggregateStats.NoDiscoveryNoScraper,
             },
-            discoveryAgents = DiscoveryAgents.ToDictionary(
-                agent => agent,
-                agent => (object)new
-                {
-                    // Organisers this agent discovered (any overlap with other agents)
-                    discoveries = agentCountTasks[agent].Result.FirstOrDefault(),
-                    // Discoveries for this agent missing lat/lon geometry.
-                    missingGeometry = agentMissingGeometryTasks[agent].Result.FirstOrDefault(),
-                    // Organisers ONLY this agent found — no other agent has them
-                    exclusive = agentExclusiveTasks[agent].Result.FirstOrDefault(),
-                }),
+            discoveryAgents = new Dictionary<string, object>
+            {
+                ["utmb"] = new { discoveries = aggregateStats.Utmb, missingGeometry = aggregateStats.UtmbMissingGeometry, exclusive = aggregateStats.UtmbExclusive },
+                ["duv"] = new { discoveries = aggregateStats.Duv, missingGeometry = aggregateStats.DuvMissingGeometry, exclusive = aggregateStats.DuvExclusive },
+                ["itra"] = new { discoveries = aggregateStats.Itra, missingGeometry = aggregateStats.ItraMissingGeometry, exclusive = aggregateStats.ItraExclusive },
+                ["tracedetrail"] = new { discoveries = aggregateStats.TraceDeTrail, missingGeometry = aggregateStats.TraceDeTrailMissingGeometry, exclusive = aggregateStats.TraceDeTrailExclusive },
+                ["runagain"] = new { discoveries = aggregateStats.RunAgain, missingGeometry = aggregateStats.RunAgainMissingGeometry, exclusive = aggregateStats.RunAgainExclusive },
+                ["loppkartan"] = new { discoveries = aggregateStats.Loppkartan, missingGeometry = aggregateStats.LoppkartanMissingGeometry, exclusive = aggregateStats.LoppkartanExclusive },
+                ["betrail"] = new { discoveries = aggregateStats.BeTrail, missingGeometry = aggregateStats.BeTrailMissingGeometry, exclusive = aggregateStats.BeTrailExclusive },
+                ["manual"] = new { discoveries = aggregateStats.Manual, missingGeometry = aggregateStats.ManualMissingGeometry, exclusive = aggregateStats.ManualExclusive },
+                ["manual-mistral"] = new { discoveries = aggregateStats.ManualMistral, missingGeometry = aggregateStats.ManualMistralMissingGeometry, exclusive = aggregateStats.ManualMistralExclusive },
+            },
             discoveryOverlap = new
             {
-                // Organisers that only a single agent ever found
                 discoveredByExactlyOneAgent = totalExclusive,
-                // Organisers that two or more agents independently found
-                discoveredByMultipleAgents = withAnyDiscovery - totalExclusive,
+                discoveredByMultipleAgents = aggregateStats.WithAnyDiscovery - totalExclusive,
             },
-            scrapers = ScraperAgents.ToDictionary(
-                scraper => scraper,
-                scraper =>
-                {
-                    var scraperTotal = scraperCountTasks[scraper].Result.FirstOrDefault();
-                    var withRoutes = scraperWithRoutesTasks[scraper].Result.FirstOrDefault();
-                    return (object)new
-                    {
-                        total = scraperTotal,
-                        withRoutes,
-                        withoutRoutes = scraperTotal - withRoutes,
-                    };
-                }),
-            topByDiscoveries = topDiscoveryOrganizersTask.Result
-                .Select(o => new
-                {
-                    DiscoveryCount = o.Discovery?.Values.Sum(list => list?.Count ?? 0) ?? 0,
-                    o.Id,
-                    o.Url,
-                    SourceUrlsByAgent = (o.Discovery ?? new Dictionary<string, List<DiscoveryUrlsOnly>>())
-                        .ToDictionary(
-                            kv => kv.Key,
-                            kv => (kv.Value ?? new List<DiscoveryUrlsOnly>())
-                                .SelectMany(d => d.SourceUrls ?? new List<string>())
-                                .Where(u => !string.IsNullOrWhiteSpace(u))
-                                .Distinct(StringComparer.OrdinalIgnoreCase)
-                                .OrderBy(u => u, StringComparer.OrdinalIgnoreCase)
-                                .ToList()),
-                })
-                .OrderByDescending(o => o.DiscoveryCount)
-                .Take(15)
-                .ToList(),
+            scrapers = new Dictionary<string, object>
+            {
+                ["utmb"] = new { total = aggregateStats.UtmbTotal, withRoutes = aggregateStats.UtmbWithRoutes, withoutRoutes = aggregateStats.UtmbTotal - aggregateStats.UtmbWithRoutes },
+                ["itra"] = new { total = aggregateStats.ItraTotal, withRoutes = aggregateStats.ItraWithRoutes, withoutRoutes = aggregateStats.ItraTotal - aggregateStats.ItraWithRoutes },
+                ["bfs"] = new { total = aggregateStats.BfsTotal, withRoutes = aggregateStats.BfsWithRoutes, withoutRoutes = aggregateStats.BfsTotal - aggregateStats.BfsWithRoutes },
+            },
+            topByDiscoveries = Array.Empty<object>(),
         };
 
         var response = req.CreateResponse(HttpStatusCode.OK);
@@ -200,6 +160,45 @@ public class GetOrganizerStats(
             && providedKeys.FirstOrDefault() == adminKey;
     }
 
-    private record TopDiscoveryOrganizer(string Id, string Url, Dictionary<string, List<DiscoveryUrlsOnly>>? Discovery);
-    private record DiscoveryUrlsOnly(List<string>? SourceUrls);
+    private record AggregateStats(
+        int Total,
+        int Assembled,
+        int WithAnyDiscovery,
+        int WithAnyScraper,
+        int WithBoth,
+        int NoDiscoveryNoScraper,
+        int Utmb,
+        int Duv,
+        int Itra,
+        int TraceDeTrail,
+        int RunAgain,
+        int Loppkartan,
+        int BeTrail,
+        int Manual,
+        int ManualMistral,
+        int UtmbExclusive,
+        int DuvExclusive,
+        int ItraExclusive,
+        int TraceDeTrailExclusive,
+        int RunAgainExclusive,
+        int LoppkartanExclusive,
+        int BeTrailExclusive,
+        int ManualExclusive,
+        int ManualMistralExclusive,
+        int UtmbMissingGeometry,
+        int DuvMissingGeometry,
+        int ItraMissingGeometry,
+        int TraceDeTrailMissingGeometry,
+        int RunAgainMissingGeometry,
+        int LoppkartanMissingGeometry,
+        int BeTrailMissingGeometry,
+        int ManualMissingGeometry,
+        int ManualMistralMissingGeometry,
+        int UtmbTotal,
+        int ItraTotal,
+        int BfsTotal,
+        int UtmbWithRoutes,
+        int ItraWithRoutes,
+        int BfsWithRoutes);
+
 }

--- a/Backend.Tests/RaceDiscoveryMessageTests.cs
+++ b/Backend.Tests/RaceDiscoveryMessageTests.cs
@@ -1,0 +1,55 @@
+using Azure.Messaging.ServiceBus;
+using Backend;
+
+namespace Backend.Tests;
+
+public class RaceDiscoveryMessageTests
+{
+    [Fact]
+    public void BuildDiscoveryServiceBusMessage_WritesJsonMessage()
+    {
+        var message = RaceDiscoveryService.BuildDiscoveryServiceBusMessage(new RaceDiscoveryMessage("duv", 3));
+
+        Assert.Equal("application/json", message.ContentType);
+        Assert.Contains("\"agent\":\"duv\"", message.Body.ToString(), StringComparison.Ordinal);
+        Assert.Contains("\"page\":3", message.Body.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DeserializeMessage_DefaultsMissingPageToFirstPage()
+    {
+        var received = ServiceBusModelFactory.ServiceBusReceivedMessage(
+            body: BinaryData.FromString("""{"agent":"tracedetrail"}"""));
+
+        var message = RaceDiscoveryWorker.DeserializeMessage(received);
+
+        Assert.NotNull(message);
+        Assert.Equal("tracedetrail", message.Agent);
+        Assert.Null(message.Page);
+        Assert.Equal(1, message.CurrentPage);
+    }
+
+    [Fact]
+    public void DeserializeMessage_AcceptsCamelCasePage()
+    {
+        var received = ServiceBusModelFactory.ServiceBusReceivedMessage(
+            body: BinaryData.FromString("""{"agent":"duv","page":4}"""));
+
+        var message = RaceDiscoveryWorker.DeserializeMessage(received);
+
+        Assert.NotNull(message);
+        Assert.Equal("duv", message.Agent);
+        Assert.Equal(4, message.Page);
+        Assert.Equal(4, message.CurrentPage);
+    }
+
+    [Fact]
+    public void TraceDeTrailPage_CoversOneMonthAtATime()
+    {
+        var firstPage = DiscoverTraceDeTrailRaces.MonthForPage(1);
+        var secondPage = DiscoverTraceDeTrailRaces.MonthForPage(2);
+
+        Assert.Equal(firstPage.AddMonths(1).Year, secondPage.Year);
+        Assert.Equal(firstPage.AddMonths(1).Month, secondPage.Month);
+    }
+}

--- a/Backend/DiscoverDuvRaces.cs
+++ b/Backend/DiscoverDuvRaces.cs
@@ -1,5 +1,6 @@
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
+using System.Net;
 
 namespace Backend;
 
@@ -11,66 +12,71 @@ public class DiscoverDuvRaces(
     [Function(nameof(DiscoverDuvRaces))]
     public async Task Run([TimerTrigger("0 0 2 * * 1")] TimerInfo timerInfo, CancellationToken cancellationToken)
     {
-        var jobs = await FetchJobsAsync(cancellationToken);
-        var keys = await discoveryService.DiscoverAndWriteAsync("duv", jobs, cancellationToken);
-        await discoveryService.EnqueueScrapeMessagesAsync(keys, cancellationToken);
+        await discoveryService.EnqueueDiscoveryMessageAsync(new RaceDiscoveryMessage("duv"), delay: null, cancellationToken);
     }
 
-    private async Task<IReadOnlyCollection<ScrapeJob>> FetchJobsAsync(CancellationToken cancellationToken)
+    public async Task<bool> ProcessPageAsync(int page, CancellationToken cancellationToken)
+    {
+        var result = await FetchPageJobsAsync(page, cancellationToken);
+        var keys = await discoveryService.DiscoverAndWriteAsync("duv", result.Jobs, cancellationToken);
+        await discoveryService.EnqueueScrapeMessagesAsync(keys, cancellationToken);
+
+        return result.HasNextPage;
+    }
+
+    private async Task<(IReadOnlyCollection<ScrapeJob> Jobs, bool HasNextPage)> FetchPageJobsAsync(int page, CancellationToken cancellationToken)
     {
         const int MaxPages = 10;
         var httpClient = httpClientFactory.CreateClient();
         var jobsByUrl = new Dictionary<string, ScrapeJob>(StringComparer.OrdinalIgnoreCase);
+        var pageUrl = BuildCalendarPageUrl(page);
 
-        for (int page = 1; page <= MaxPages; page++)
+        using (var response = await httpClient.GetAsync(pageUrl, cancellationToken))
         {
-            var pageUrl = page == 1
-                ? DuvDiscoveryAgent.CalendarUrl
-                : new UriBuilder(DuvDiscoveryAgent.CalendarUrl) { Query = $"page={page}" }.Uri;
+            if (response.StatusCode == HttpStatusCode.TooManyRequests)
+                throw new HttpRequestException($"DUV calendar returned 429 for page {page}", null, response.StatusCode);
 
-            try
+            response.EnsureSuccessStatusCode();
+
+            var html = await response.Content.ReadAsStringAsync(cancellationToken);
+            var jobs = DuvDiscoveryAgent.ParseCalendarPage(html, DuvDiscoveryAgent.CalendarUrl);
+
+            foreach (var job in jobs)
             {
-                var html = await httpClient.GetStringAsync(pageUrl, cancellationToken);
-                var jobs = DuvDiscoveryAgent.ParseCalendarPage(html, DuvDiscoveryAgent.CalendarUrl);
-                if (jobs.Count == 0) break;
-
-                foreach (var job in jobs)
-                {
-                    if (job.WebsiteUrl is not null)
-                        jobsByUrl.TryAdd(job.WebsiteUrl.AbsoluteUri, job);
-                }
-
-                if (!html.Contains($"calendar.php?&page={page + 1}", StringComparison.OrdinalIgnoreCase))
-                    break;
+                if (job.WebsiteUrl is not null)
+                    jobsByUrl.TryAdd(job.WebsiteUrl.AbsoluteUri, job);
             }
-            catch (Exception ex) when (ex is not OperationCanceledException)
-            {
-                logger.LogWarning(ex, "DUV: failed to fetch calendar page {Page}", page);
-                break;
-            }
+
+            var hasNextPage = page < MaxPages
+                && jobs.Count > 0
+                && html.Contains($"calendar.php?&page={page + 1}", StringComparison.OrdinalIgnoreCase);
+
+            logger.LogInformation("DUV: discovered {Count} calendar events on page {Page}", jobsByUrl.Count, page);
+            return (await EnrichJobsAsync(httpClient, jobsByUrl.Values, cancellationToken), hasNextPage);
         }
+    }
 
-        logger.LogInformation("DUV: discovered {Count} calendar events", jobsByUrl.Count);
-
-        var enriched = new List<ScrapeJob>(jobsByUrl.Count);
-        foreach (var job in jobsByUrl.Values)
+    private async Task<IReadOnlyCollection<ScrapeJob>> EnrichJobsAsync(
+        HttpClient httpClient,
+        IEnumerable<ScrapeJob> jobs,
+        CancellationToken cancellationToken)
+    {
+        var enriched = new List<ScrapeJob>();
+        foreach (var job in jobs)
         {
             if (job.WebsiteUrl is null)
             {
                 enriched.Add(job);
                 continue;
             }
-            try
-            {
-                enriched.Add(await DuvDiscoveryAgent.EnrichJobAsync(httpClient, job, cancellationToken));
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException)
-            {
-                logger.LogWarning(ex, "DUV: failed to fetch event detail page for {Url}", job.WebsiteUrl);
-                enriched.Add(job);
-            }
+            enriched.Add(await DuvDiscoveryAgent.EnrichJobAsync(httpClient, job, cancellationToken));
         }
 
         return enriched.ToArray();
     }
+
+    private static Uri BuildCalendarPageUrl(int page)
+        => page <= 1
+            ? DuvDiscoveryAgent.CalendarUrl
+            : new UriBuilder(DuvDiscoveryAgent.CalendarUrl) { Query = $"page={page}" }.Uri;
 }

--- a/Backend/DiscoverItraRaces.cs
+++ b/Backend/DiscoverItraRaces.cs
@@ -29,12 +29,30 @@ public class DiscoverItraRaces(
     [Function(nameof(DiscoverItraRaces))]
     public async Task Run([TimerTrigger("0 0 2 * * 1")] TimerInfo timerInfo, CancellationToken cancellationToken)
     {
-        var jobs = await FetchJobsAsync(cancellationToken);
-        var keys = await discoveryService.DiscoverAndWriteAsync("itra", jobs, cancellationToken);
-        await discoveryService.EnqueueScrapeMessagesAsync(keys, cancellationToken);
+        await discoveryService.EnqueueDiscoveryMessageAsync(new RaceDiscoveryMessage("itra"), delay: null, cancellationToken);
     }
 
-    private async Task<IReadOnlyCollection<ScrapeJob>> FetchJobsAsync(CancellationToken cancellationToken)
+    public async Task<bool> ProcessPageAsync(int page, CancellationToken cancellationToken)
+    {
+        if (page < 1 || page > TotalPages)
+        {
+            logger.LogWarning("ITRA discovery page {Page} is outside valid range 1..{TotalPages}", page, TotalPages);
+            return false;
+        }
+
+        var country = CountryCodes[page - 1];
+        logger.LogInformation("ITRA: discovering country {Country} on page {Page}/{TotalPages}", country, page, TotalPages);
+
+        var jobs = await FetchJobsAsync(country, cancellationToken);
+        var keys = await discoveryService.DiscoverAndWriteAsync("itra", jobs, cancellationToken);
+        await discoveryService.EnqueueScrapeMessagesAsync(keys, cancellationToken);
+
+        return page < TotalPages;
+    }
+
+    private static int TotalPages => CountryCodes.Length;
+
+    private async Task<IReadOnlyCollection<ScrapeJob>> FetchJobsAsync(string country, CancellationToken cancellationToken)
     {
         try
         {
@@ -70,95 +88,58 @@ public class DiscoverItraRaces(
                 logger.LogWarning("ITRA: failed to extract antiforgery token from calendar page (html length={Length})", initialHtml.Length);
                 return [];
             }
-            logger.LogInformation("ITRA: got antiforgery token, starting country-by-country discovery");
+            logger.LogInformation("ITRA: got antiforgery token, starting discovery for country {Country}", country);
 
-            var allJobs = new List<ScrapeJob>();
-            var seenUrls = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            var got429 = false;
+            List<KeyValuePair<string, string>> fields =
+            [
+                new("__RequestVerificationToken", token),
+                new("Input.Longitude", "0"),
+                new("Input.Latitude", "0"),
+                new("Input.NorthEastLat", "90"),
+                new("Input.NorthEastLng", "180"),
+                new("Input.SouthWestLat", "-90"),
+                new("Input.SouthWestLng", "-180"),
+                new("Input.MinDistance", ""),
+                new("Input.MaxDistance", ""),
+                new("Input.MinElevationGain", ""),
+                new("Input.MaxElevationGain", ""),
+                new("Input.MinElevationLoss", ""),
+                new("Input.MaxElevationLoss", ""),
+                new("Input.MinItraPts", "0"),
+                new("Input.MaxItraPts", "7"),
+                new("Input.ItraPtsValue", "0"),
+                new("Input.NationalLeagues", "false"),
+                new("Input.NationalLeague", "false"),
+                new("Input.DateValue", ""),
+                new("Input.DateStart", ""),
+                new("Input.DateEnd", ""),
+                new("Input.resultcount", "0"),
+                new("Input.RaceValue", ""),
+                new("Input.Country", country),
+                new("ZoomLevel", "2"),
+                new("type", ""),
+                new("countMap", "1"),
+            ];
 
-            await Parallel.ForEachAsync(CountryCodes,
-                new ParallelOptions { MaxDegreeOfParallelism = 5, CancellationToken = cancellationToken },
-                async (country, ct) =>
+            using var request = new HttpRequestMessage(HttpMethod.Post, ItraDiscoveryAgent.CalendarUrl)
             {
-                if (got429) return;
+                Content = new FormUrlEncodedContent(fields)
+            };
+            request.Headers.Referrer = ItraDiscoveryAgent.CalendarUrl;
 
-                List<KeyValuePair<string, string>> fields =
-                [
-                    new("__RequestVerificationToken", token),
-                    new("Input.Longitude", "0"),
-                    new("Input.Latitude", "0"),
-                    new("Input.NorthEastLat", "90"),
-                    new("Input.NorthEastLng", "180"),
-                    new("Input.SouthWestLat", "-90"),
-                    new("Input.SouthWestLng", "-180"),
-                    new("Input.MinDistance", ""),
-                    new("Input.MaxDistance", ""),
-                    new("Input.MinElevationGain", ""),
-                    new("Input.MaxElevationGain", ""),
-                    new("Input.MinElevationLoss", ""),
-                    new("Input.MaxElevationLoss", ""),
-                    new("Input.MinItraPts", "0"),
-                    new("Input.MaxItraPts", "7"),
-                    new("Input.ItraPtsValue", "0"),
-                    new("Input.NationalLeagues", "false"),
-                    new("Input.NationalLeague", "false"),
-                    new("Input.DateValue", ""),
-                    new("Input.DateStart", ""),
-                    new("Input.DateEnd", ""),
-                    new("Input.resultcount", "0"),
-                    new("Input.RaceValue", ""),
-                    new("Input.Country", country),
-                    new("ZoomLevel", "2"),
-                    new("type", ""),
-                    new("countMap", "1"),
-                ];
+            using var response = await client.SendAsync(request, cancellationToken);
+            if (response.StatusCode == HttpStatusCode.TooManyRequests)
+                throw new HttpRequestException($"ITRA calendar returned 429 for country {country}", null, response.StatusCode);
 
-                try
-                {
-                    using var request = new HttpRequestMessage(HttpMethod.Post, ItraDiscoveryAgent.CalendarUrl)
-                    {
-                        Content = new FormUrlEncodedContent(fields)
-                    };
-                    request.Headers.Referrer = ItraDiscoveryAgent.CalendarUrl;
+            response.EnsureSuccessStatusCode();
 
-                    using var response = await client.SendAsync(request, ct);
-                    if (response.StatusCode == HttpStatusCode.TooManyRequests)
-                    {
-                        logger.LogWarning("ITRA: received 429 for country {Country}, stopping discovery", country);
-                        got429 = true;
-                        return;
-                    }
-                    response.EnsureSuccessStatusCode();
+            var html = await response.Content.ReadAsStringAsync(cancellationToken);
+            var page = ItraDiscoveryAgent.ParseCalendarPage(html, ItraDiscoveryAgent.CalendarUrl);
 
-                    var html = await response.Content.ReadAsStringAsync(ct);
-                    var page = ItraDiscoveryAgent.ParseCalendarPage(html, ItraDiscoveryAgent.CalendarUrl);
+            var jobs = page.ToArray();
+            logger.LogInformation("ITRA: discovered {Count} races for country {Country}", jobs.Length, country);
 
-                    int newCount = 0;
-                    lock (seenUrls)
-                    {
-                        foreach (var job in page)
-                        {
-                            var key = job.WebsiteUrl?.AbsoluteUri ?? job.ItraEventPageUrl?.AbsoluteUri;
-                            if (key is null || seenUrls.Add(key))
-                            {
-                                allJobs.Add(job);
-                                newCount++;
-                            }
-                        }
-                    }
-
-                    if (page.Count > 0)
-                        logger.LogInformation("ITRA: {Country} → {Count} races ({New} new){Cap}", country, page.Count, newCount,
-                            page.Count >= 300 ? " *** MAY BE CAPPED ***" : "");
-                }
-                catch (Exception ex) when (ex is not OperationCanceledException || ex is TaskCanceledException { CancellationToken.IsCancellationRequested: false })
-                {
-                    logger.LogWarning(ex, "ITRA: failed to fetch country {Country}", country);
-                }
-            });
-
-            logger.LogInformation("ITRA: discovered {Count} races before enrichment", allJobs.Count);
-            var enrichedJobs = await ItraDiscoveryAgent.EnrichEventPageDetailsAsync(allJobs, client, cancellationToken,
+            var enrichedJobs = await ItraDiscoveryAgent.EnrichEventPageDetailsAsync(jobs, client, cancellationToken,
                 onProgress: (done, total) =>
                 {
                     if (done == -1)

--- a/Backend/DiscoverTraceDeTrailRaces.cs
+++ b/Backend/DiscoverTraceDeTrailRaces.cs
@@ -1,6 +1,7 @@
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 using Shared.Services;
+using System.Globalization;
 using System.Net;
 
 namespace Backend;
@@ -13,84 +14,68 @@ public class DiscoverTraceDeTrailRaces(
 {
     private static readonly Uri CalendarUrl = new("https://tracedetrail.fr/event/getEventsCalendar/all/all/all");
     private const string CalendarReferer = "https://tracedetrail.fr/en/calendar";
-    private const int MaxRequestsPerRun = 450;
+    private const int StartMonthOffset = -12;
+    private const int EndMonthOffset = 12;
 
     [Function(nameof(DiscoverTraceDeTrailRaces))]
     public async Task Run([TimerTrigger("0 0 2 * * 1")] TimerInfo timerInfo, CancellationToken cancellationToken)
     {
-        var jobs = await FetchJobsAsync(cancellationToken);
-        var keys = await discoveryService.DiscoverAndWriteAsync("tracedetrail", jobs, cancellationToken);
-        await discoveryService.EnqueueScrapeMessagesAsync(keys, cancellationToken);
+        await discoveryService.EnqueueDiscoveryMessageAsync(new RaceDiscoveryMessage("tracedetrail"), delay: null, cancellationToken);
     }
 
-    private async Task<IReadOnlyCollection<ScrapeJob>> FetchJobsAsync(CancellationToken cancellationToken)
+    public async Task<bool> ProcessPageAsync(int page, CancellationToken cancellationToken)
+    {
+        var jobs = await FetchPageJobsAsync(page, cancellationToken);
+        var keys = await discoveryService.DiscoverAndWriteAsync("tracedetrail", jobs, cancellationToken);
+        await discoveryService.EnqueueScrapeMessagesAsync(keys, cancellationToken);
+
+        return page < TotalPages;
+    }
+
+    private async Task<IReadOnlyCollection<ScrapeJob>> FetchPageJobsAsync(int page, CancellationToken cancellationToken)
     {
         var httpClient = httpClientFactory.CreateClient();
         var jobsByUrl = new Dictionary<string, ScrapeJob>(StringComparer.OrdinalIgnoreCase);
-        var now = DateTime.UtcNow;
         var knownTraceDeTrailIds = await organizerClient.FetchKnownTraceDeTrailIdsAsync(cancellationToken);
         int skippedKnownEvents = 0;
-        var requestsRemaining = MaxRequestsPerRun;
+        var date = MonthForPage(page);
 
-        foreach (var monthOffset in Enumerable.Range(-12, 25))
+        using var request = new HttpRequestMessage(HttpMethod.Post, CalendarUrl)
         {
-            if (requestsRemaining <= 0) break;
+            Content = new FormUrlEncodedContent(
+            [
+                new KeyValuePair<string, string>("month", date.Month.ToString(CultureInfo.InvariantCulture)),
+                new KeyValuePair<string, string>("year", date.Year.ToString(CultureInfo.InvariantCulture))
+            ]),
+        };
+        request.Headers.Referrer = new Uri(CalendarReferer);
 
-            var date = now.AddMonths(monthOffset);
-            try
+        using var response = await httpClient.SendAsync(request, cancellationToken);
+        if (response.StatusCode == HttpStatusCode.TooManyRequests)
+            throw new HttpRequestException($"TraceDeTrail calendar returned 429 for {date.Month}/{date.Year}", null, response.StatusCode);
+
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsStringAsync(cancellationToken);
+        foreach (var job in RaceScrapeDiscovery.ParseTraceDeTrailCalendarEvents(json))
+        {
+            var eventId = job.ExternalIds?.TryGetValue("tracedetrailEventId", out var tId) == true ? tId : null;
+            var itraEventId = job.ExternalIds?.TryGetValue("itraEventId", out var iId) == true ? iId : null;
+
+            if ((!string.IsNullOrWhiteSpace(eventId) && knownTraceDeTrailIds.Contains(eventId!))
+                || (!string.IsNullOrWhiteSpace(itraEventId) && knownTraceDeTrailIds.Contains(itraEventId!)))
             {
-                using var request = new HttpRequestMessage(HttpMethod.Post, CalendarUrl)
-                {
-                    Content = new FormUrlEncodedContent(
-                    [
-                        new KeyValuePair<string, string>("month", date.Month.ToString(System.Globalization.CultureInfo.InvariantCulture)),
-                        new KeyValuePair<string, string>("year", date.Year.ToString(System.Globalization.CultureInfo.InvariantCulture))
-                    ]),
-                };
-                request.Headers.Referrer = new Uri(CalendarReferer);
-
-                using var response = await httpClient.SendAsync(request, cancellationToken);
-                requestsRemaining--;
-
-                if (response.StatusCode == HttpStatusCode.TooManyRequests)
-                {
-                    logger.LogWarning("TraceDeTrail: calendar returned 429 for {Month}/{Year}, stopping", date.Month, date.Year);
-                    break;
-                }
-
-                if (!response.IsSuccessStatusCode)
-                {
-                    logger.LogWarning("TraceDeTrail: calendar returned {Status} for {Month}/{Year}", response.StatusCode, date.Month, date.Year);
-                    await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
-                    continue;
-                }
-
-                var json = await response.Content.ReadAsStringAsync(cancellationToken);
-                foreach (var job in RaceScrapeDiscovery.ParseTraceDeTrailCalendarEvents(json))
-                {
-                    var eventId = job.ExternalIds?.TryGetValue("tracedetrailEventId", out var tId) == true ? tId : null;
-                    var itraEventId = job.ExternalIds?.TryGetValue("itraEventId", out var iId) == true ? iId : null;
-
-                    if ((!string.IsNullOrWhiteSpace(eventId) && knownTraceDeTrailIds.Contains(eventId!))
-                        || (!string.IsNullOrWhiteSpace(itraEventId) && knownTraceDeTrailIds.Contains(itraEventId!)))
-                    {
-                        skippedKnownEvents++;
-                        continue;
-                    }
-
-                    var key = job.TraceDeTrailItraUrls?.FirstOrDefault()?.AbsoluteUri ?? job.TraceDeTrailEventUrl?.AbsoluteUri;
-                    if (key is not null)
-                        jobsByUrl.TryAdd(key, job);
-                }
+                skippedKnownEvents++;
+                continue;
             }
-            catch (Exception ex) when (ex is not OperationCanceledException)
-            {
-                logger.LogWarning(ex, "TraceDeTrail: failed to fetch calendar for {Month}/{Year}", date.Month, date.Year);
-            }
+
+            var key = job.TraceDeTrailItraUrls?.FirstOrDefault()?.AbsoluteUri ?? job.TraceDeTrailEventUrl?.AbsoluteUri;
+            if (key is not null)
+                jobsByUrl.TryAdd(key, job);
         }
 
-        logger.LogInformation("TraceDeTrail: discovered {Count} unique jobs, skipped {Skipped} already-known events, requests remaining {Remaining}, enriching with site URLs…",
-            jobsByUrl.Count, skippedKnownEvents, requestsRemaining);
+        logger.LogInformation("TraceDeTrail: discovered {Count} unique jobs, skipped {Skipped} already-known events for {Month}/{Year}, enriching with site URLs",
+            jobsByUrl.Count, skippedKnownEvents, date.Month, date.Year);
 
         var enriched = new List<ScrapeJob>(jobsByUrl.Count);
         var stoppedEventEnrichment = false;
@@ -98,26 +83,23 @@ public class DiscoverTraceDeTrailRaces(
 
         foreach (var job in jobsByUrl.Values)
         {
-            if (job.TraceDeTrailEventUrl is null || stoppedEventEnrichment || requestsRemaining <= 0)
+            if (job.TraceDeTrailEventUrl is null || stoppedEventEnrichment)
                 continue;
 
-            using var response = await httpClient.GetAsync(job.TraceDeTrailEventUrl, cancellationToken);
-            requestsRemaining--;
+            using var eventResponse = await httpClient.GetAsync(job.TraceDeTrailEventUrl, cancellationToken);
 
-            if (response.StatusCode == HttpStatusCode.TooManyRequests)
+            if (eventResponse.StatusCode == HttpStatusCode.TooManyRequests)
             {
-                stoppedEventEnrichment = true;
-                logger.LogWarning("TraceDeTrail: received 429 from {Url}, stopping event page enrichment", job.TraceDeTrailEventUrl);
+                throw new HttpRequestException($"TraceDeTrail event page returned 429 for {job.TraceDeTrailEventUrl}", null, response.StatusCode);
+            }
+
+            if (!eventResponse.IsSuccessStatusCode)
+            {
+                logger.LogDebug("TraceDeTrail: {Status} fetching {Url}", eventResponse.StatusCode, job.TraceDeTrailEventUrl);
                 continue;
             }
 
-            if (!response.IsSuccessStatusCode)
-            {
-                logger.LogDebug("TraceDeTrail: {Status} fetching {Url}", response.StatusCode, job.TraceDeTrailEventUrl);
-                continue;
-            }
-
-            var html = await response.Content.ReadAsStringAsync(cancellationToken);
+            var html = await eventResponse.Content.ReadAsStringAsync(cancellationToken);
             var siteUrl = RaceHtmlScraper.ExtractRaceSiteUrl(html, job.TraceDeTrailEventUrl);
             var location = RaceHtmlScraper.ExtractTraceDeTrailLocation(html);
 
@@ -171,4 +153,9 @@ public class DiscoverTraceDeTrailRaces(
         logger.LogInformation("TraceDeTrail: resolved {Resolved}/{Total} event site URLs", resolved, jobsByUrl.Count);
         return enriched.ToArray();
     }
+
+    private static int TotalPages => EndMonthOffset - StartMonthOffset + 1;
+
+    internal static DateTime MonthForPage(int page)
+        => DateTime.UtcNow.AddMonths(StartMonthOffset + Math.Max(page, 1) - 1);
 }

--- a/Backend/DiscoverTraceDeTrailRaces.cs
+++ b/Backend/DiscoverTraceDeTrailRaces.cs
@@ -36,8 +36,6 @@ public class DiscoverTraceDeTrailRaces(
     {
         var httpClient = httpClientFactory.CreateClient();
         var jobsByUrl = new Dictionary<string, ScrapeJob>(StringComparer.OrdinalIgnoreCase);
-        var knownTraceDeTrailIds = await organizerClient.FetchKnownTraceDeTrailIdsAsync(cancellationToken);
-        int skippedKnownEvents = 0;
         var date = MonthForPage(page);
 
         using var request = new HttpRequestMessage(HttpMethod.Post, CalendarUrl)
@@ -59,23 +57,13 @@ public class DiscoverTraceDeTrailRaces(
         var json = await response.Content.ReadAsStringAsync(cancellationToken);
         foreach (var job in RaceScrapeDiscovery.ParseTraceDeTrailCalendarEvents(json))
         {
-            var eventId = job.ExternalIds?.TryGetValue("tracedetrailEventId", out var tId) == true ? tId : null;
-            var itraEventId = job.ExternalIds?.TryGetValue("itraEventId", out var iId) == true ? iId : null;
-
-            if ((!string.IsNullOrWhiteSpace(eventId) && knownTraceDeTrailIds.Contains(eventId!))
-                || (!string.IsNullOrWhiteSpace(itraEventId) && knownTraceDeTrailIds.Contains(itraEventId!)))
-            {
-                skippedKnownEvents++;
-                continue;
-            }
-
             var key = job.TraceDeTrailItraUrls?.FirstOrDefault()?.AbsoluteUri ?? job.TraceDeTrailEventUrl?.AbsoluteUri;
             if (key is not null)
                 jobsByUrl.TryAdd(key, job);
         }
 
-        logger.LogInformation("TraceDeTrail: discovered {Count} unique jobs, skipped {Skipped} already-known events for {Month}/{Year}, enriching with site URLs",
-            jobsByUrl.Count, skippedKnownEvents, date.Month, date.Year);
+        logger.LogInformation("TraceDeTrail: discovered {Count} unique jobs for {Month}/{Year}, enriching with site URLs",
+            jobsByUrl.Count, date.Month, date.Year);
 
         var enriched = new List<ScrapeJob>(jobsByUrl.Count);
         var stoppedEventEnrichment = false;

--- a/Backend/Program.cs
+++ b/Backend/Program.cs
@@ -130,6 +130,8 @@ var host = new HostBuilder()
             return new SummitsCalculatorWithBoundingBoxFilter();
         });
         services.AddSingleton<RaceDiscoveryService>();
+        services.AddSingleton<DiscoverDuvRaces>();
+        services.AddSingleton<DiscoverTraceDeTrailRaces>();
     })
     .Build();
 

--- a/Backend/Program.cs
+++ b/Backend/Program.cs
@@ -132,6 +132,7 @@ var host = new HostBuilder()
         services.AddSingleton<RaceDiscoveryService>();
         services.AddSingleton<DiscoverDuvRaces>();
         services.AddSingleton<DiscoverTraceDeTrailRaces>();
+        services.AddSingleton<DiscoverItraRaces>();
     })
     .Build();
 

--- a/Backend/RaceDiscoveryService.cs
+++ b/Backend/RaceDiscoveryService.cs
@@ -2,13 +2,16 @@ using Azure.Messaging.ServiceBus;
 using Microsoft.Extensions.Logging;
 using Shared.Constants;
 using Shared.Services;
+using System.Text.Json;
 
 namespace Backend;
 
 public class RaceDiscoveryService(ServiceBusClient serviceBusClient, RaceOrganizerClient organizerClient, ILoggerFactory loggerFactory)
 {
     private readonly ServiceBusSender _sender = serviceBusClient.CreateSender(ServiceBusConfig.ScrapeRace);
+    private readonly ServiceBusSender _discoverySender = serviceBusClient.CreateSender(ServiceBusConfig.RaceDiscoveryJobs);
     private readonly ILogger _logger = loggerFactory.CreateLogger<RaceDiscoveryService>();
+    private static readonly JsonSerializerOptions JsonSerializerOptions = new(JsonSerializerDefaults.Web);
 
     public async Task<IReadOnlySet<string>> DiscoverAndWriteAsync(
         string source,
@@ -51,4 +54,32 @@ public class RaceDiscoveryService(ServiceBusClient serviceBusClient, RaceOrganiz
 
         _logger.LogInformation("Enqueued {Count} scrape messages", messages.Count);
     }
+
+    public async Task EnqueueDiscoveryMessageAsync(
+        RaceDiscoveryMessage message,
+        TimeSpan? delay,
+        CancellationToken cancellationToken)
+    {
+        var serviceBusMessage = BuildDiscoveryServiceBusMessage(message);
+        if (delay.HasValue)
+            serviceBusMessage.ScheduledEnqueueTime = DateTimeOffset.UtcNow.Add(delay.Value);
+
+        await _discoverySender.SendMessageAsync(serviceBusMessage, cancellationToken);
+        _logger.LogInformation("Enqueued race discovery message for {Agent} page {Page}", message.Agent, message.Page);
+    }
+
+    public static ServiceBusMessage BuildDiscoveryServiceBusMessage(RaceDiscoveryMessage message)
+    {
+        var body = BinaryData.FromString(JsonSerializer.Serialize(message, JsonSerializerOptions));
+        return new ServiceBusMessage(body)
+        {
+            ContentType = "application/json",
+            MessageId = $"{message.Agent}:{message.Page ?? 1}:{Guid.NewGuid()}"
+        };
+    }
+}
+
+public sealed record RaceDiscoveryMessage(string Agent, int? Page = null)
+{
+    public int CurrentPage => Page.GetValueOrDefault(1);
 }

--- a/Backend/RaceDiscoveryWorker.cs
+++ b/Backend/RaceDiscoveryWorker.cs
@@ -9,6 +9,7 @@ namespace Backend;
 public class RaceDiscoveryWorker(
     DiscoverDuvRaces duvDiscovery,
     DiscoverTraceDeTrailRaces traceDeTrailDiscovery,
+    DiscoverItraRaces itraDiscovery,
     RaceDiscoveryService discoveryService,
     ILogger<RaceDiscoveryWorker> logger)
 {
@@ -56,6 +57,7 @@ public class RaceDiscoveryWorker(
             {
                 "duv" => await duvDiscovery.ProcessPageAsync(normalizedMessage.CurrentPage, cancellationToken),
                 "tracedetrail" => await traceDeTrailDiscovery.ProcessPageAsync(normalizedMessage.CurrentPage, cancellationToken),
+                "itra" => await itraDiscovery.ProcessPageAsync(normalizedMessage.CurrentPage, cancellationToken),
                 _ => throw new NotSupportedException($"Unknown race discovery agent '{normalizedMessage.Agent}'.")
             };
 

--- a/Backend/RaceDiscoveryWorker.cs
+++ b/Backend/RaceDiscoveryWorker.cs
@@ -1,0 +1,90 @@
+using System.Text.Json;
+using Azure.Messaging.ServiceBus;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+using Shared.Constants;
+
+namespace Backend;
+
+public class RaceDiscoveryWorker(
+    DiscoverDuvRaces duvDiscovery,
+    DiscoverTraceDeTrailRaces traceDeTrailDiscovery,
+    RaceDiscoveryService discoveryService,
+    ILogger<RaceDiscoveryWorker> logger)
+{
+    private static readonly TimeSpan RetryDelay = TimeSpan.FromMinutes(10);
+    private static readonly JsonSerializerOptions JsonSerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    [Function(nameof(RaceDiscoveryWorker))]
+    public async Task Run(
+        [ServiceBusTrigger(ServiceBusConfig.RaceDiscoveryJobs, Connection = "ServicebusConnection", AutoCompleteMessages = false)]
+        ServiceBusReceivedMessage message,
+        ServiceBusMessageActions actions,
+        CancellationToken cancellationToken)
+    {
+        RaceDiscoveryMessage? discoveryMessage;
+        try
+        {
+            discoveryMessage = DeserializeMessage(message);
+        }
+        catch (JsonException ex)
+        {
+            logger.LogWarning(ex, "Race discovery message {MessageId} is not valid JSON", message.MessageId);
+            await actions.DeadLetterMessageAsync(message,
+                deadLetterReason: "InvalidMessage",
+                deadLetterErrorDescription: ex.Message,
+                cancellationToken: cancellationToken);
+            return;
+        }
+
+        if (discoveryMessage is null || string.IsNullOrWhiteSpace(discoveryMessage.Agent))
+        {
+            await actions.DeadLetterMessageAsync(message,
+                deadLetterReason: "InvalidMessage",
+                deadLetterErrorDescription: "Race discovery message requires an agent.",
+                cancellationToken: cancellationToken);
+            return;
+        }
+
+        var normalizedMessage = discoveryMessage with { Agent = discoveryMessage.Agent.Trim().ToLowerInvariant() };
+        try
+        {
+            var hasNextPage = normalizedMessage.Agent switch
+            {
+                "duv" => await duvDiscovery.ProcessPageAsync(normalizedMessage.CurrentPage, cancellationToken),
+                "tracedetrail" => await traceDeTrailDiscovery.ProcessPageAsync(normalizedMessage.CurrentPage, cancellationToken),
+                _ => throw new NotSupportedException($"Unknown race discovery agent '{normalizedMessage.Agent}'.")
+            };
+
+            if (hasNextPage)
+                await discoveryService.EnqueueDiscoveryMessageAsync(
+                    normalizedMessage with { Page = normalizedMessage.CurrentPage + 1 },
+                    delay: null,
+                    cancellationToken);
+
+            await actions.CompleteMessageAsync(message, cancellationToken);
+        }
+        catch (NotSupportedException ex)
+        {
+            logger.LogWarning(ex, "Unsupported race discovery agent {Agent}", normalizedMessage.Agent);
+            await actions.DeadLetterMessageAsync(message,
+                deadLetterReason: "UnsupportedAgent",
+                deadLetterErrorDescription: ex.Message,
+                cancellationToken: cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            await discoveryService.EnqueueDiscoveryMessageAsync(normalizedMessage, RetryDelay, cancellationToken);
+            logger.LogWarning(ex,
+                "Race discovery {Agent} page {Page} failed; rescheduled same page after {Delay}",
+                normalizedMessage.Agent, normalizedMessage.CurrentPage, RetryDelay);
+            await actions.CompleteMessageAsync(message, cancellationToken);
+        }
+    }
+
+    internal static RaceDiscoveryMessage? DeserializeMessage(ServiceBusReceivedMessage message)
+        => JsonSerializer.Deserialize<RaceDiscoveryMessage>(message.Body, JsonSerializerOptions);
+}

--- a/Backend/RaceHtmlScraper.cs
+++ b/Backend/RaceHtmlScraper.cs
@@ -1026,7 +1026,7 @@ public static partial class RaceHtmlScraper
         var tldIdx = host.LastIndexOf('.');
         if (tldIdx > 0) host = host[..tldIdx];
         // Split on dots and hyphens.
-        return host.Split(['.', '-'], StringSplitOptions.RemoveEmptyEntries)
+        return host.Split(new[] { '.', '-' }, StringSplitOptions.RemoveEmptyEntries)
             .Where(w => w.Length >= 3)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
     }

--- a/Backend/RaceScrapeDiscovery.cs
+++ b/Backend/RaceScrapeDiscovery.cs
@@ -183,7 +183,7 @@ public static partial class RaceScrapeDiscovery
             return null;
 
         var parts = distanceVerbose
-            .Split([',', ';'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            .Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
         string? bestToken = null;
         double bestDelta = double.MaxValue;
@@ -221,7 +221,7 @@ public static partial class RaceScrapeDiscovery
             return null;
 
         var parts = distanceVerbose
-            .Split([',', ';'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            .Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
         var formatted = new List<string>(parts.Length);
         foreach (var part in parts)
@@ -1510,7 +1510,7 @@ public static partial class RaceScrapeDiscovery
     private static IReadOnlyList<(double Km, string Formatted)> ParseVerboseDistanceParts(string distanceVerbose)
     {
         var parts = distanceVerbose
-            .Split([',', ';'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            .Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
         var result = new List<(double, string)>(parts.Length);
         foreach (var part in parts)

--- a/Shared/Constants/ServiceBusConfig.cs
+++ b/Shared/Constants/ServiceBusConfig.cs
@@ -9,6 +9,7 @@ namespace Shared.Constants
         public const string ActivityFetchJobs = "activityFetchJobs";
         public const string ActivityProcessed = "activityprocessed";
         public const string ScrapeRace = "scrapeRace";
+        public const string RaceDiscoveryJobs = "raceDiscoveryJobs";
         public const string MistralScrapeJobs = "mistralScrape";
         public const string AssembleRace = "assembleRace";
         public const string EnrichAdminBoundaryJobs = "enrichAdminBoundaryJobs";

--- a/Shared/Services/RaceOrganizerClient.cs
+++ b/Shared/Services/RaceOrganizerClient.cs
@@ -302,27 +302,6 @@ public class RaceOrganizerClient(Container container, ILoggerFactory loggerFacto
         }
     }
 
-    public async Task<HashSet<string>> FetchKnownTraceDeTrailIdsAsync(CancellationToken cancellationToken = default)
-    {
-        var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        var tracedetrailQuery = new QueryDefinition(
-            "SELECT VALUE s.externalIds.tracedetrailEventId FROM c JOIN s IN c.discovery.tracedetrail " +
-            "WHERE IS_DEFINED(s.externalIds.tracedetrailEventId)");
-        var tracedetrailIds = await ExecuteQueryAsync<string>(tracedetrailQuery, cancellationToken: cancellationToken);
-        foreach (var id in tracedetrailIds.Where(id => !string.IsNullOrWhiteSpace(id)))
-            ids.Add(id!);
-
-        var itraQuery = new QueryDefinition(
-            "SELECT VALUE s.externalIds.itraEventId FROM c JOIN s IN c.discovery.tracedetrail " +
-            "WHERE IS_DEFINED(s.externalIds.itraEventId)");
-        var itraIds = await ExecuteQueryAsync<string>(itraQuery, cancellationToken: cancellationToken);
-        foreach (var id in itraIds.Where(id => !string.IsNullOrWhiteSpace(id)))
-            ids.Add(id!);
-
-        return ids;
-    }
-
     /// <summary>
     /// Patches the <c>lastAssembledUtc</c> field on an existing organizer document.
     /// </summary>

--- a/Shared/Services/RaceTypeNormalizer.cs
+++ b/Shared/Services/RaceTypeNormalizer.cs
@@ -8,7 +8,7 @@ public static class RaceTypeNormalizer
             return null;
 
         var parts = raceType
-            .Split([',', ';', '/', '_'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Split(new[] { ',', ';', '/', '_' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
             .Select(p => p.ToLowerInvariant())
             .Select(p => RaceTypeAliases.TryGetValue(p, out var mapped) ? mapped : p)
             .Where(p => p.Length > 0)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add a shared `raceDiscoveryJobs` Service Bus worker for `duv` and `tracedetrail` discovery messages.
- Change DUV and TraceDeTrail timers into queue seeders and process one page/month per message.
- Reschedule failed discovery pages after 10 minutes and enqueue the next page after success.
- Add tests for discovery message JSON/default page behavior and TraceDeTrail month paging.

### Testing
- `dotnet test Backend.Tests/Backend.Tests.csproj`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7853859b-2ea9-4102-a1eb-dfade40da641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7853859b-2ea9-4102-a1eb-dfade40da641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

